### PR TITLE
Prefer standard json library over simplejson.

### DIFF
--- a/tvnamer/main.py
+++ b/tvnamer/main.py
@@ -17,7 +17,11 @@ try:
 except ImportError:
     pass
 
-import simplejson as json
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
 from tvdb_api import Tvdb
 
 import cliarg_parser


### PR DESCRIPTION
Nice and simple, just means we don't need to depend on simplejson for current versions of python(2.6+) which include it in the standard library.
