### PR TITLE
Support relative arguments for config load/save

### DIFF
--- a/tvnamer/main.py
+++ b/tvnamer/main.py
@@ -357,7 +357,7 @@ def main():
     if configToLoad is not None:
         p("Loading config: %s" % (configToLoad))
         try:
-            loadedConfig = json.load(open(configToLoad))
+            loadedConfig = json.load(open(os.path.expanduser(configToLoad)))
         except ValueError, e:
             p("Error loading config: %s" % e)
             opter.exit(1)
@@ -380,7 +380,7 @@ def main():
         del configToSave['showconfig']
         json.dump(
             configToSave,
-            open(opts.saveconfig, "w+"),
+            open(os.path.expanduser(opts.saveconfig), "w+"),
             sort_keys=True,
             indent=4)
 


### PR DESCRIPTION
At the moment only the default configuration file path is ran through expanduser, this pull modifies load/save to be processed through expanduser, allowing for: `tvnamer --save=~/.tvnamer.json` to be used without error.
