### PR TITLE
intuitive filename blacklist

### DIFF
--- a/tvnamer/utils.py
+++ b/tvnamer/utils.py
@@ -196,7 +196,7 @@ class FileFinder(object):
 
         self.with_blacklist should be a list of strings and/or dicts:
 
-        a string, specifying a specific file name to ignore
+        a string, specifying an exact filename to ignore
         "filename_blacklist": [".DS_Store", "Thumbs.db"], 
 
         a dictionary, where each dict contains:


### PR DESCRIPTION
filename_blacklist should be able to accept a simple string
specifying an exact filename you would like to ignore.

example:
"filename_blacklist": [".DS_Store", "Thumbs.db"],

I believe this is a more intuitive use of a filename blacklist and the
ability to add a dict with advanced functionality still exists.
