### PR TITLE
Add leave_symlink option

### DIFF
--- a/tvnamer/config_defaults.py
+++ b/tvnamer/config_defaults.py
@@ -124,6 +124,10 @@ defaults = {
     # volume, after the copy has complete.
     'always_move': False,
 
+    # Whenever a file is moved leave a symlink to the new file behind, named
+    # after the original file.
+    'leave_symlink': False,
+
     # Allow user to copy files to specified move location without renaming files.
     'move_files_only': False,
 

--- a/tvnamer/main.py
+++ b/tvnamer/main.py
@@ -89,7 +89,7 @@ def doRenameFile(cnamer, newName):
     newName should be string containing new filename.
     """
     try:
-        cnamer.newName(newName, force = Config['overwrite_destination_on_rename'])
+        cnamer.newName(newName, force = Config['overwrite_destination_on_rename'], leave_symlink = Config['leave_symlink'])
     except OSError, e:
         warn(e)
 
@@ -112,6 +112,7 @@ def doMoveFile(cnamer, destDir = None, destFilepath = None, getPathPreview = Fal
             new_path = destDir,
             new_fullpath = destFilepath,
             always_move = Config['always_move'],
+            leave_symlink = Config['leave_symlink'],
             getPathPreview = getPathPreview,
             force = Config['overwrite_destination_on_move'])
 


### PR DESCRIPTION
Each time a file is moved/renamed a symlink is left behind, named after the
just-moved file, pointing to the new location. Since at present the file is
moved twice (once for the rename, again for the move) two symlinks are made.
This isn't ideal in my opinion but it'll do for now.
