### PR TITLE
Add basic data adjustment capabilities

### DIFF
--- a/tvnamer/config_defaults.py
+++ b/tvnamer/config_defaults.py
@@ -439,4 +439,9 @@ defaults = {
     # since these are perfectly predictable, they are simple strings
     # not regular expressions
     'output_series_replacements': {},
+
+    # adjust episode data if source order diverges from TVDB
+    # format is a dict {<seriesid> : {"episode_number": <x>, "season_number": <x>}}
+    # where x is a basic math expression string, eg. "+1" or "-2"
+    'data_adjustment': {}
 }

--- a/tvnamer/utils.py
+++ b/tvnamer/utils.py
@@ -616,6 +616,11 @@ class EpisodeInfo(object):
             # Series was found, use corrected series name
             self.seriesname = replaceOutputSeriesName(show['seriesname'])
 
+        da = Config['data_adjustment'].get(show['id'], {})
+        for cepno in self.episodenumbers:
+            self.episodenumbers[self.episodenumbers.index(cepno)] = cepno + eval(da.get("episode_number", "0"), {'__builtins__' : {}})
+
+
         if isinstance(self, DatedEpisodeInfo):
             # Date-based episode
             epnames = []
@@ -638,6 +643,7 @@ class EpisodeInfo(object):
             # Series without concept of seasons have all episodes in season 1
             seasonnumber = 1
         else:
+            self.seasonnumber += eval(da.get("season_number", "0"), {'__builtins__' : {}})
             seasonnumber = self.seasonnumber
 
         epnames = []


### PR DESCRIPTION
Some tv show releases diverge in their episode or season numbering from tvdb numbers, leading to false renames. An example of that is American Dad, which is currently released as season 8 when it is actually airing season 9, which results from season 1 and 2 being released together as season 1 on dvd.

This changeset makes it possible to adjust episode and season numbering manually in the config.
