### PR TITLE
Add --use-folder-name option

### DIFF
--- a/tvnamer/cliarg_parser.py
+++ b/tvnamer/cliarg_parser.py
@@ -65,6 +65,7 @@ def getCommandlineParser(defaults):
     with Group(parser, "Override values") as g:
         g.add_option("-n", "--name", action="store", dest = "force_name", help = "override the parsed series name with this (applies to all files)")
         g.add_option("--series-id", action="store", dest = "series_id", help = "explicitly set the show id for TVdb to use (applies to all files)")
+        g.add_option("--use-folder-name", action="store_true", dest = "use_folder_name", help = "Use the parent folder name help determine the series name")
 
     # Misc
     with Group(parser, "Misc") as g:

--- a/tvnamer/main.py
+++ b/tvnamer/main.py
@@ -167,7 +167,7 @@ def processFile(tvdb_instance, episode):
     p("# Detected series: %s (%s)" % (episode.seriesname, episode.number_string()))
 
     try:
-        episode.populateFromTvdb(tvdb_instance, force_name=Config['force_name'], series_id=Config['series_id'])
+        episode.populateFromTvdb(tvdb_instance, force_name=Config['force_name'], series_id=Config['series_id'], use_folder_name=Config['use_folder_name'])
     except (DataRetrievalError, ShowNotFound), errormsg:
         if Config['always_rename'] and Config['skip_file_on_error'] is True:
             warn("Skipping file due to error: %s" % errormsg)
@@ -302,7 +302,7 @@ def tvnamer(paths):
         except InvalidFilename, e:
             warn("Invalid filename: %s" % e)
         else:
-            if episode.seriesname is None and Config['force_name'] is None and Config['series_id'] is None:
+            if episode.seriesname is None and Config['force_name'] is None and Config['series_id'] is None and Config['use_folder_name'] is None:
                 warn("Parsed filename did not contain series name (and --name or --series-id not specified), skipping: %s" % cfile)
 
             else:

--- a/tvnamer/utils.py
+++ b/tvnamer/utils.py
@@ -620,7 +620,7 @@ class EpisodeInfo(object):
             self.seasonnumber,
             ", ".join([str(x) for x in self.episodenumbers]))
 
-    def populateFromTvdb(self, tvdb_instance, force_name=None, series_id=None):
+    def populateFromTvdb(self, tvdb_instance, force_name=None, series_id=None, use_folder_name=None):
         """Queries the tvdb_api.Tvdb instance for episode name and corrected
         series name.
         If series cannot be found, it will warn the user. If the episode is not
@@ -629,12 +629,14 @@ class EpisodeInfo(object):
         it will catch tvdb_api's user abort error and raise tvnamer's
         """
         try:
-            if series_id is None:
-                show = tvdb_instance[force_name or self.seriesname]
-            else:
+            if series_id:
                 series_id = int(series_id)
                 tvdb_instance._getShowData(series_id, Config['language'])
                 show = tvdb_instance[series_id]
+            elif use_folder_name:
+                show = tvdb_instance[os.path.split(self.filepath)[1]]
+            else:
+                show = tvdb_instance[force_name or self.seriesname]
         except tvdb_error, errormsg:
             raise DataRetrievalError("Error with www.thetvdb.com: %s" % errormsg)
         except tvdb_shownotfound:


### PR DESCRIPTION
--use-folder-name will attempt to pick the series name from the name of the parent folder.

If you are in the folder "/foo/bar/Star_Trek_the_Next_Generation" and you run "--batch --use-folder-name ." it should correctly detect the name of the series if the episodes do not contain it.
