### PR TITLE
One operation for renaming and file move & fixe for episodes without seasons

### DIFF
--- a/tvnamer/main.py
+++ b/tvnamer/main.py
@@ -95,7 +95,7 @@ def doRenameFile(cnamer, newName):
         warn(e)
 
 
-def doMoveFile(cnamer, destDir = None, destFilepath = None, getPathPreview = False):
+def doMoveFile(cnamer, destDir = None, destFilepath = None, getPathPreview = False, newName = None):
     """Moves file to destDir, or to destFilepath
     """
 
@@ -109,13 +109,21 @@ def doMoveFile(cnamer, destDir = None, destFilepath = None, getPathPreview = Fal
         raise ValueError("Config value for move_files_destination cannot be None if move_files_enabled is True")
 
     try:
-        return cnamer.newPath(
-            new_path = destDir,
-            new_fullpath = destFilepath,
-            always_move = Config['always_move'],
-            leave_symlink = Config['leave_symlink'],
-            getPathPreview = getPathPreview,
-            force = Config['overwrite_destination_on_move'])
+        if (newName is None):
+            return cnamer.newPath(
+	        new_path = destDir,
+	        new_fullpath = destFilepath,
+	        always_move = Config['always_move'],
+	        leave_symlink = Config['leave_symlink'],
+	        getPathPreview = getPathPreview,
+	        force = Config['overwrite_destination_on_move'])
+        else:
+            return cnamer.newPath(
+                new_fullpath = destDir + os.sep + newName,
+                always_move = Config['always_move'],
+                leave_symlink = Config['leave_symlink'],
+                getPathPreview = getPathPreview,
+                force = Config['overwrite_destination_on_move'])
 
     except OSError, e:
         warn(e)
@@ -213,12 +221,14 @@ def processFile(tvdb_instance, episode):
             p("New filename: %s" % newName)
 
             if Config['always_rename']:
-                doRenameFile(cnamer, newName)
                 if Config['move_files_enable']:
                     if Config['move_files_destination_is_filepath']:
+	                doRenameFile(cnamer, newName) # TODO: understand this option
                         doMoveFile(cnamer = cnamer, destFilepath = getMoveDestination(episode))
                     else:
-                        doMoveFile(cnamer = cnamer, destDir = getMoveDestination(episode))
+                        doMoveFile(cnamer = cnamer, destDir = getMoveDestination(episode) , newName = newName)
+		else:
+                    doRenameFile(cnamer, newName)
                 return
 
             ans = confirm("Rename?", options = ['y', 'n', 'a', 'q'], default = 'y')
@@ -246,7 +256,7 @@ def processFile(tvdb_instance, episode):
         if Config['move_files_destination_is_filepath']:
             doMoveFile(cnamer = cnamer, destFilepath = newPath, getPathPreview = True)
         else:
-            doMoveFile(cnamer = cnamer, destDir = newPath, getPathPreview = True)
+            doMoveFile(cnamer = cnamer, destDir = newPath, getPathPreview = True, newName = newName )
 
         if not Config['batch'] and Config['move_files_confirmation']:
             ans = confirm("Move file?", options = ['y', 'n', 'q'], default = 'y')


### PR DESCRIPTION
This will fix two bugs that were affecting me.

**1. Fallback to season 0 for episodes without a defined season**

 For anime episodes that don't have a registered season it was returning a bug instead of falling back to no episode at all. This will fallback to season 0

**2. One step for renaming and moving**

  If the configuration was set to rename and move files this would be done in a two step operation, first rename on the file's original directory and then move to the new path

This poses a problem when leaving symlinks behind as it would leave two symlinks in the original directory and a another symlink in the destination path (if run twice)

Example:
/original/path/Naruto Shippuuden - 323 [1080p].mkv

First run would result on (with always_move, leave_symlink and always_rename = true):
_(symlink)_ /original/path/Naruto Shippuuden - 323 [1080p].mkv
_(symlink)_ /original/path/Naruto Shippuuden - 323 - The Five Kage Assemble [1080p].mkv
(file) /new/path/Naruto Shippuuden - 323 [1080p].mkv

Second run would also create the following symlink:
_(symlink)_ /new/path/Naruto Shippuuden - 323 - The Five Kage Assemble [1080p].mkv

ps. I wasn't able to separate these two pull requests after looking up documentation. If someone could show me how I can separate these
