### PR TITLE
Properly handle failure to update times

### DIFF
--- a/tvnamer/utils.py
+++ b/tvnamer/utils.py
@@ -10,6 +10,7 @@ import sys
 import shutil
 import logging
 import platform
+import errno
 
 from tvdb_api import (tvdb_error, tvdb_shownotfound, tvdb_seasonnotfound,
 tvdb_episodenotfound, tvdb_attributenotfound, tvdb_userabort)
@@ -1000,8 +1001,14 @@ def rename_file(old, new):
     p("rename %s to %s" % (old, new))
     stat = os.stat(old)
     os.rename(old, new)
-    os.utime(new, (stat.st_atime, stat.st_mtime))
-
+    try:
+        os.utime(new, (stat.st_atime, stat.st_mtime))
+    except OSError, ex:
+        if ex.errno == errno.EPERM:
+            warn("WARNING: Could not preserve times for %s "
+                 "(owner UID mismatch?)" % new)
+        else:
+            raise
 
 def copy_file(old, new):
     p("copy %s to %s" % (old, new))


### PR DESCRIPTION
Linux won't allow utime() to be called on a file that's not _owned_ by
the current user (even if it is writable by him). This causes a problem
for people running their torrent software as one user, but tvnamer as
another.

See http://dbr.lighthouseapp.com/projects/36049/tickets/130-After-Recent-tvnamer-Update for an example.
