### PR TITLE
Properly handle failure to update times

### DIFF
--- a/tvnamer/renamer.py
+++ b/tvnamer/renamer.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import logging
+import errno
 
 from unicode_helper import p
 
@@ -51,7 +52,14 @@ def rename_file(old, new):
     log().debug("Renaming %r to %r" % (old, new))
     stat = os.stat(old)
     os.rename(old, new)
-    os.utime(new, (stat.st_atime, stat.st_mtime))
+    try:
+        os.utime(new, (stat.st_atime, stat.st_mtime))
+    except OSError, ex:
+        if ex.errno == errno.EPERM:
+            log().warn("WARNING: Could not preserve times for %s "
+                       "(owner UID mismatch?)" % new)
+        else:
+            raise
 
 
 def copy_file(old, new):


### PR DESCRIPTION
Linux won't allow utime() to be called on a file that's not _owned_ by
the current user (even if it is writable by him). This causes a problem
for people running their torrent software as one user, but tvnamer as
another.

Note, this is the same as #89 but for the `ver3` branch.
