### PR TITLE
Added hardlink and copy options

### DIFF
--- a/tvnamer/cliarg_parser.py
+++ b/tvnamer/cliarg_parser.py
@@ -66,6 +66,12 @@ def getCommandlineParser(defaults):
         g.add_option("-m", "--move", action="store_true", dest="move_files_enable", help = "Move files to destination specified in config or with --movedestination argument")
         g.add_option("--not-move", action="store_false", dest="move_files_enable", help = "Files will remain in current directory")
 
+        g.add_option("-C", "--copy", action="store_true", dest="always_copy", help = "Copy files instead of renaming")
+        g.add_option("--not-copy", action="store_false", dest="always_copy", help = "Files will not be copied")
+
+        g.add_option("-l", "--link", action="store_true", dest="always_hardlink", help = "Hardlink instead of renaming")
+        g.add_option("--not-link", action="store_false", dest="always_hardlink", help = "Files will not all be hardlink")
+
         g.add_option("--force-move", action="store_true", dest = "overwrite_destination_on_move", help = "Force move and potentially overwrite existing files in destination folder")
         g.add_option("--force-rename", action="store_true", dest = "overwrite_destination_on_rename", help = "Force rename source file")
 

--- a/tvnamer/config_defaults.py
+++ b/tvnamer/config_defaults.py
@@ -14,7 +14,7 @@ defaults = {
     'batch': False,
 
     # Fail if error finding show data (thetvdb.com is down etc)
-    # Only functions when always_rename is True
+    # Only functions when always_rename or always_hardlink are True
     'skip_file_on_error': True,
     
     # Fail if error finding show data (thetvdb.com is down etc)
@@ -145,6 +145,18 @@ defaults = {
 
     # Allow user to copy files to specified move location without renaming files.
     'move_files_only': False,
+
+    # Force the move-files feature to always copy the file.
+    'always_copy': False,
+
+    # If True, instead of copying files to be copied on the same partition,
+    # a hardlink will be created.
+    'prefer_hardlink_to_copy': False,
+
+    # Forces files to be hard-linked. Will raise an error if it is not possible
+    # (i.e. different partition, unsuported, etc.).
+    # This option is incompatible with always_move
+    'always_hardlink': False,
 
     # Patterns to parse input filenames with
     'filename_patterns': [

--- a/tvnamer/utils.py
+++ b/tvnamer/utils.py
@@ -1034,7 +1034,7 @@ class Renamer(object):
     def __init__(self, filename):
         self.filename = os.path.abspath(filename)
 
-    def newPath(self, new_path = None, new_fullpath = None, force = False, always_copy = False, always_move = False, always_hardlink = False, leave_symlink = False, create_dirs = True, getPathPreview = False):
+    def newPath(self, new_path = None, new_fullpath = None, force = False, always_copy = False, prefer_hardlink_to_copy = False, always_move = False, always_hardlink = False, leave_symlink = False, create_dirs = True, getPathPreview = False):
         """Moves the file to a new path.
 
         If it is on the same partition, it will be moved (unless always_copy is True)


### PR DESCRIPTION
This PR adds the ability to leave original files untouched and copy or create a hard link to them.
I think it answers issues partially #46, I think #40 and #10 

I added the command line options:
- `-C` or `--copy` To copy a file (compatible with -d option)
- `-l` or `--link` To hard link a file (compatible with -d option)

I added the config options:
- `always_copy` To always copy files
- `prefer_hardlink_to_copy` To create a hardlink when possible if copying
- `always_hardlink` To always hardlink

I am quite new to this tool (and to contributing) so I may have not seen some corner cases.
The biggest change I had to do is renaming file after moving/copying them. This was to avoid making too many changes to the code base.