### PR TITLE
Added the ability for the user to specify a priori what TVDb id to use for specific series names

### DIFF
--- a/tvnamer/config_defaults.py
+++ b/tvnamer/config_defaults.py
@@ -453,6 +453,11 @@ defaults = {
     # filenames, for instance adding or removing the year, or expanding abbreviations
     'input_series_replacements': {},
 
+    # set what TVDB id to use for a given input series name
+    # these are queried after input_series_replacements are done
+    # but do not require an entry in that dictionary to be used
+    'series_tvdb_ids': {},
+
     # output replacements are for transforms of the TVDB series names
     # since these are perfectly predictable, they are simple strings
     # not regular expressions

--- a/tvnamer/main.py
+++ b/tvnamer/main.py
@@ -167,7 +167,12 @@ def processFile(tvdb_instance, episode):
         episode.seriesname = Config['force_name']
 
     p("# Detected series: %s (%s)" % (episode.seriesname, episode.number_string()))
-
+    
+    if Config['series_tvdb_ids'][episode.seriesname] is not None:
+        series_id=Config['series_tvdb_ids'][episode.seriesname]
+    else:
+        series_id=Config['series_id']
+    
     try:
         episode.populateFromTvdb(tvdb_instance, force_name=Config['force_name'], series_id=Config['series_id'])
     except (DataRetrievalError, ShowNotFound) as errormsg:

--- a/tvnamer/main.py
+++ b/tvnamer/main.py
@@ -168,9 +168,10 @@ def processFile(tvdb_instance, episode):
 
     p("# Detected series: %s (%s)" % (episode.seriesname, episode.number_string()))
     
-    if Config['series_tvdb_ids'][episode.seriesname] is not None:
-        series_id=Config['series_tvdb_ids'][episode.seriesname]
-    else:
+    try:
+        if Config['series_tvdb_ids'][episode.seriesname] is not None:
+            series_id=Config['series_tvdb_ids'][episode.seriesname]
+    except KeyError:
         series_id=Config['series_id']
     
     try:


### PR DESCRIPTION
This enables a deterministic, single-result search which improves the ability to automate the process.

I tried my best to add this functionality without altering or breaking how it works currently; e.g. the command-line option `--series-id=${tvdb_id}` still overrides anything in the user's dotfile or the default config.