### PR TITLE
Fix seriesname typo from seriesnami

### DIFF
--- a/tvnamer/utils.py
+++ b/tvnamer/utils.py
@@ -652,7 +652,7 @@ class EpisodeInfo(object):
             raise UserAbort(string_type(error))
         else:
             # Series was found, use corrected series name
-            self.seriesnami = replaceOutputSeriesName(show['seriesName'])
+            self.seriesname = replaceOutputSeriesName(show['seriesName'])
 
         if isinstance(self, DatedEpisodeInfo):
             # Date-based episode


### PR DESCRIPTION
Simple typo fix for self.seriesname. This caused seriesname to be valid for formatting the file name but it had a stale value.

#202 